### PR TITLE
Fix for autocomplete and some enhancements

### DIFF
--- a/PPJEmailPicker/NSString+PPJEmailValidation.h
+++ b/PPJEmailPicker/NSString+PPJEmailValidation.h
@@ -1,0 +1,13 @@
+//
+//  NSString+PPJEmailValidation.h
+//  Pods
+//
+//  Created by Nacho on 2/8/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSString (PPJEmailValidation)
+- (BOOL)isValidEmail;
+@end

--- a/PPJEmailPicker/NSString+PPJEmailValidation.m
+++ b/PPJEmailPicker/NSString+PPJEmailValidation.m
@@ -1,0 +1,20 @@
+//
+//  NSString+PPJEmailValidation.m
+//  Pods
+//
+//  Created by Nacho on 2/8/16.
+//
+//
+
+#import "NSString+PPJEmailValidation.h"
+
+@implementation NSString (PPJEmailValidation)
+- (BOOL)isValidEmail
+{
+  const char cRegex[] = "^(?!(?:(?:\\x22?\\x5C[\\x00-\\x7E]\\x22?)|(?:\\x22?[^\\x5C\\x22]\\x22?)){255,})(?!(?:(?:\\x22?\\x5C[\\x00-\\x7E]\\x22?)|(?:\\x22?[^\\x5C\\x22]\\x22?)){65,}@)(?:(?:[\\x21\\x23-\\x27\\x2A\\x2B\\x2D\\x2F-\\x39\\x3D\\x3F\\x5E-\\x7E]+)|(?:\\x22(?:[\\x01-\\x08\\x0B\\x0C\\x0E-\\x1F\\x21\\x23-\\x5B\\x5D-\\x7F]|(?:\\x5C[\\x00-\\x7F]))*\\x22))(?:\\.(?:(?:[\\x21\\x23-\\x27\\x2A\\x2B\\x2D\\x2F-\\x39\\x3D\\x3F\\x5E-\\x7E]+)|(?:\\x22(?:[\\x01-\\x08\\x0B\\x0C\\x0E-\\x1F\\x21\\x23-\\x5B\\x5D-\\x7F]|(?:\\x5C[\\x00-\\x7F]))*\\x22)))*@(?:(?:(?!.*[^.]{64,})(?:(?:(?:xn--)?[a-z0-9]+(?:-+[a-z0-9]+)*\\.){1,126}){1,}(?:(?:[a-z][a-z0-9]*)|(?:(?:xn--)[a-z0-9]+))(?:-+[a-z0-9]+)*)|(?:\\[(?:(?:IPv6:(?:(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){7})|(?:(?!(?:.*[a-f0-9][:\\]]){7,})(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,5})?::(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,5})?)))|(?:(?:IPv6:(?:(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){5}:)|(?:(?!(?:.*[a-f0-9]:){5,})(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,3})?::(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,3}:)?)))?(?:(?:25[0-5])|(?:2[0-4][0-9])|(?:1[0-9]{2})|(?:[1-9]?[0-9]))(?:\\.(?:(?:25[0-5])|(?:2[0-4][0-9])|(?:1[0-9]{2})|(?:[1-9]?[0-9]))){3}))\\]))$";
+  NSString *emailRegex = [NSString stringWithUTF8String:cRegex];
+  NSPredicate *emailPredicate = [NSPredicate predicateWithFormat:@"SELF MATCHES[c] %@", emailRegex];
+  BOOL isValid = [emailPredicate evaluateWithObject:self];
+  return isValid;
+}
+@end

--- a/PPJEmailPicker/PPJEmailPicker.h
+++ b/PPJEmailPicker/PPJEmailPicker.h
@@ -36,6 +36,7 @@
 //
 - (BOOL)PPJ_TextField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string;
 - (BOOL)PPJ_textFieldShouldReturn:(UITextField *)txtField;
+- (BOOL)PPJ_textFieldShouldEndEditing:(UITextField *)txtField;
 
 
 -(void) showDropDown:(NSInteger)numberOfRows;

--- a/PPJEmailPicker/PPJEmailPicker.h
+++ b/PPJEmailPicker/PPJEmailPicker.h
@@ -18,7 +18,6 @@
 @property (assign, nonatomic) BOOL                         emailPickerTableViewHidden;
 @property (assign, nonatomic) BOOL                         makeTextFieldDropShadowWithAutoCompleteTableOpen;
 @property (assign, nonatomic) CGRect                       emailPickerTableViewFrame;
-@property (assign, nonatomic) CGFloat                      tableHeight;
 @property (copy,  nonatomic ) NSMutableArray              *selectedEmailList;
 @property (copy,  nonatomic ) NSArray                     *possibleStrings;
 @property (assign, nonatomic) CGFloat                      minimumHeight;

--- a/PPJEmailPicker/PPJEmailPicker.m
+++ b/PPJEmailPicker/PPJEmailPicker.m
@@ -103,7 +103,9 @@
 -(void) commonInit
 {
 	[self initDelegate];
-	self.tableHeight                          = 100.0f;
+  self.autocorrectionType                   = UITextAutocorrectionTypeNo;
+  self.keyboardType                         = UIKeyboardTypeEmailAddress;
+  self.autocapitalizationType               = UITextAutocapitalizationTypeNone;
 	_emailPickerTableView                     = [self newEmailPickerTableViewForTextField:self];
 	self.inset                                = UIEdgeInsetsZero;
 	self.selectedEmailUI                      = [@[] mutableCopy];
@@ -320,10 +322,9 @@
 		[self closeDropDown];
 		return;
 	}
-	if (![self isDropDownVisible]) {
-		[self showDropDown:count];
-	}
+  [self showDropDown:count];
 	[self.emailPickerTableView reloadData];
+  [self.emailPickerTableView flashScrollIndicators];
 }
 
 #pragma mark - TableView Data Source
@@ -334,7 +335,7 @@
 
 -(NSInteger) tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
-	return (self.possibleStringsFiltered.count > 3)?3:self.possibleStringsFiltered.count;
+	return self.possibleStringsFiltered.count;
 }
 
 -(UITableViewCell *) tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
@@ -438,7 +439,7 @@
 		frame.origin.y += textField.frame.size.height;
 	}
 	
-	frame.size.height += textField.tableHeight;
+	frame.size.height = MIN(textField.numberOfAutocompleteRows, [textField.emailPickerTableView.dataSource tableView:textField.emailPickerTableView numberOfRowsInSection:0]) * textField.autoCompleteRowHeight;
 	frame = CGRectInset(frame, 1, 0);
 	
 	return frame;

--- a/PPJEmailPicker/PPJEmailPicker.m
+++ b/PPJEmailPicker/PPJEmailPicker.m
@@ -8,6 +8,7 @@
 
 #import "PPJEmailPicker.h"
 #import "PPJCommon.h"
+#import "NSString+PPJEmailValidation.h"
 #define PPJEMAILPICKER_PADDING_X 5
 #define PPJEMAILPICKER_PADDING_Y 2
 
@@ -44,6 +45,15 @@
 		resp = resp && [_userDelegate textFieldShouldReturn:textField];
 	}
 	return resp;
+}
+
+- (BOOL)textFieldShouldEndEditing:(UITextField *)textField
+{
+  BOOL resp = [(PPJEmailPicker *)textField PPJ_textFieldShouldEndEditing:textField];
+  if (resp && [_userDelegate respondsToSelector:_cmd]) {
+    resp = resp && [_userDelegate textFieldShouldEndEditing:textField];
+  }
+  return resp;
 }
 
 @end
@@ -570,6 +580,17 @@
 		txtField.text = @"";
 	}
 	return NO;
+}
+
+- (BOOL)PPJ_textFieldShouldEndEditing:(UITextField *)txtField
+{
+  NSString * add = txtField.text;
+  if ([add isValidEmail]) {
+    [self addString:add];
+    [self closeDropDown];
+    txtField.text = @"";
+  }
+  return YES;
 }
 
 @end

--- a/PPJEmailPicker/PPJEmailPicker.m
+++ b/PPJEmailPicker/PPJEmailPicker.m
@@ -306,7 +306,7 @@
 	filter = filter.lowercaseString;
 	NSMutableArray *m = [NSMutableArray array];
 	for (NSString * string in self.possibleStrings) {
-		if ([string hasPrefix:filter])
+		if ([[string lowercaseString] hasPrefix:filter])
 		{
 			[m addObject:string];
 		}

--- a/PPJEmailPickerDemo.xcodeproj/project.pbxproj
+++ b/PPJEmailPickerDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		661EBBD31D50BA8700F03F07 /* NSString+PPJEmailValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = 661EBBD11D50BA8700F03F07 /* NSString+PPJEmailValidation.m */; };
 		9F0D9B661CEB69A700B2635E /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D9B651CEB69A700B2635E /* main.m */; };
 		9F0D9B691CEB69A700B2635E /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D9B681CEB69A700B2635E /* AppDelegate.m */; };
 		9F0D9B6C1CEB69A700B2635E /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D9B6B1CEB69A700B2635E /* ViewController.m */; };
@@ -46,6 +47,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		661EBBD11D50BA8700F03F07 /* NSString+PPJEmailValidation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSString+PPJEmailValidation.m"; path = "PPJEmailPicker/NSString+PPJEmailValidation.m"; sourceTree = SOURCE_ROOT; };
+		661EBBD21D50BA8700F03F07 /* NSString+PPJEmailValidation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSString+PPJEmailValidation.h"; path = "PPJEmailPicker/NSString+PPJEmailValidation.h"; sourceTree = SOURCE_ROOT; };
 		9F0D9B611CEB69A700B2635E /* PPJEmailPickerDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PPJEmailPickerDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F0D9B651CEB69A700B2635E /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		9F0D9B671CEB69A700B2635E /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -170,6 +173,8 @@
 		9F0D9B971CEB69BE00B2635E /* PPJEmailPicker */ = {
 			isa = PBXGroup;
 			children = (
+				661EBBD11D50BA8700F03F07 /* NSString+PPJEmailValidation.m */,
+				661EBBD21D50BA8700F03F07 /* NSString+PPJEmailValidation.h */,
 				9F598B2D1CF4E1C9004245CB /* PPJCommon.h */,
 				9F0D9B981CEB6A0C00B2635E /* PPJEmailPicker.h */,
 				9F0D9B991CEB6A0C00B2635E /* PPJEmailPicker.m */,
@@ -315,6 +320,7 @@
 				9F0D9B6C1CEB69A700B2635E /* ViewController.m in Sources */,
 				9F20436A1CEB928D0031F557 /* PPJSelectableLabel.m in Sources */,
 				9F0D9B691CEB69A700B2635E /* AppDelegate.m in Sources */,
+				661EBBD31D50BA8700F03F07 /* NSString+PPJEmailValidation.m in Sources */,
 				9F598B211CF336F7004245CB /* ListOfEmails.m in Sources */,
 				9F0D9B661CEB69A700B2635E /* main.m in Sources */,
 				9F0D9B9A1CEB6A0C00B2635E /* PPJEmailPicker.m in Sources */,


### PR DESCRIPTION
I have opened this PR to fix an issue with autocomplete and I have also applied some enhancements.
- Fix
  - Autocomplete feature was not able to find emails that match the pattern typed but were introduced with capital characters.
- Enhancements
  - Applied some default values to `autocorrectionType`, `autocapitalizationType` and `keyboardType`
  - Height of the autocomplete tableView is now calculated dynamically depending on the number of results, the maximum number of row displayed and the height for each row
  - Autocomplete list displays all results that match the pattern, instead of returning only the first 3
  - When textField lose focus, if it contains a valid email address, it is added to the list of emails
