### PR TITLE
Fix for recipients still appearing as suggestions

### DIFF
--- a/PPJEmailPicker/PPJEmailPicker.m
+++ b/PPJEmailPicker/PPJEmailPicker.m
@@ -323,7 +323,8 @@
 	filter = filter.lowercaseString;
 	NSMutableArray *m = [NSMutableArray array];
 	for (NSString * string in self.possibleStrings) {
-		if ([[string lowercaseString] rangeOfString:filter].location != NSNotFound)
+        BOOL exists = [self.selectedEmailList filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"SELF contains[c] %@", [string sanitizeString]]].count > 0;
+        if (([[string lowercaseString] rangeOfString:filter].location != NSNotFound) && (!exists))
 		{
 			[m addObject:string];
 		}


### PR DESCRIPTION
## Description
This PR fix the issue with suggestions still appearing after being added as recipients. Now if a user adds an email to the list, this email should not appear as a suggestion anymore.

## Screenshot
![recipients-not-included-into-suggestions](https://cloud.githubusercontent.com/assets/2726409/20896232/fec0fcc4-bb1c-11e6-8ab7-e7131dff9470.gif)
