### PR TITLE
Refresh UI after introducing emails manually

### DIFF
--- a/PPJEmailPicker/PPJEmailPicker.m
+++ b/PPJEmailPicker/PPJEmailPicker.m
@@ -578,6 +578,7 @@
 		NSString * add = textField.text;
 		if (add.length > 0) {
 			[self addString:add];
+            [self layoutIfNeeded];
 			[self closeDropDown];
 			textField.text = @"";
 		}
@@ -594,6 +595,7 @@
 	NSString * add = txtField.text;
 	if (add.length > 0) {
 		[self addString:add];
+        [self layoutIfNeeded];
 		[self closeDropDown];
 		txtField.text = @"";
 	}
@@ -605,6 +607,7 @@
   NSString * add = txtField.text;
   if ([add isValidEmail]) {
     [self addString:add];
+    [self layoutIfNeeded];
     [self closeDropDown];
     txtField.text = @"";
   }


### PR DESCRIPTION
## Description
This PR fix an issue where cursor is misplaced after manually introducing emails (through space typing or return key)

![cursor-misplaced](https://cloud.githubusercontent.com/assets/2726409/21764359/f4e702b4-d662-11e6-98e6-f6815fb86e66.gif)


## Screenshot
![cursor-misplaced-fix](https://cloud.githubusercontent.com/assets/2726409/21764406/2c4606ec-d663-11e6-8f6f-29a2070fac23.gif)