### PR TITLE
Fix for crash when selecting cell that is not backed up by datasource anymore

### DIFF
--- a/PPJEmailPicker/PPJEmailPicker.m
+++ b/PPJEmailPicker/PPJEmailPicker.m
@@ -434,6 +434,11 @@
 
 -(void) tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
+    if (indexPath.row >= self.possibleStrings.count)
+    {
+        return;
+    }
+    
 	[self addString:self.possibleStringsFiltered[indexPath.row]];
     [self layoutIfNeeded];
 	[tableView deselectRowAtIndexPath:indexPath animated:YES];


### PR DESCRIPTION
## Description
This PR fix a crash when user selects a cell that is not backed up by datasource array anymore.