### PR TITLE
Fix for initial height calculation not notified to delegate

### DIFF
--- a/PPJEmailPicker/PPJEmailPicker.m
+++ b/PPJEmailPicker/PPJEmailPicker.m
@@ -267,8 +267,13 @@
         finalFrame.size = CGSizeMake(finalFrame.size.width, height);
 	}
 	
-	self.frame = finalFrame;
-	self.emailPickerTableView.frame = [self emailPickerTableViewFrameForTextField:self];
+    BOOL heightChanged = CGRectGetHeight(self.frame) != CGRectGetHeight(finalFrame);
+    self.frame = finalFrame;
+    self.emailPickerTableView.frame = [self emailPickerTableViewFrameForTextField:self];
+    if (heightChanged && [self.pickerDelegate respondsToSelector:@selector(picker:changedHeight:)]) {
+        CGFloat height = CGRectGetHeight(finalFrame);
+        [self.pickerDelegate picker:self changedHeight:height];
+    }
 }
 
 // placeholder position


### PR DESCRIPTION
## Description
There is an issue when initially fedding PPJEmailPicker with a list of emails. Component is calculating correctly his height based in the content in method `layoutSubviews`, but it is not notifying the delegate about the change in height. Because of this, if this component is added within a tableview cell, cell is not able to detect the change and resize.

<img width="345" alt="screen shot 2018-01-19 at 12 14 07" src="https://user-images.githubusercontent.com/2726409/35148450-78e08186-fd12-11e7-9c90-15bcc0061078.png">
